### PR TITLE
Grab Tutorial tag if exsits

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,8 +44,24 @@ file(
 include(${CMAKE_CURRENT_BINARY_DIR}/cmake/CPM.cmake)
 
 ##################################  MaCh3  ######################################
+# KS: Here we try to find tag matching tutorial version. If we can't find one then use develop
+# This will allow to grab tutorial for tagged MaCh3 version without a need of manually changing version
 if(NOT DEFINED MaCh3_Branch)
-  SET(MaCh3_Branch "develop")
+  set(REPO_URL "https://api.github.com/repos/mach3-software/MaCh3/tags")
+  # Execute curl to fetch the tags from GitHub
+  execute_process(
+      COMMAND curl -s ${REPO_URL}
+      OUTPUT_VARIABLE curl_output
+      OUTPUT_STRIP_TRAILING_WHITESPACE
+  )
+  # Check if the tag exists in the response
+  string(FIND "${curl_output}" "\"name\": \"v${MaCh3Tutorial_VERSION}\"" tag_found_index)
+
+  if(tag_found_index GREATER -1)
+      SET(MaCh3_Branch "tags/v${MaCh3Tutorial_VERSION}")
+  else()
+      SET(MaCh3_Branch "develop")
+  endif()
 endif()
 
 #If MaCh3 was sourced find it, otherwise use CPM


### PR DESCRIPTION
# Pull request description:
if tag exist and version not specyfied grab tutoria version correspidning to the tag. This will allow tags of tutorial to be more easyli accesible wihtout a need of manyually selecting branch

## Changes or fixes:


## Examples:
For valdiations swithced tutorial verstion to 1.2.0 and it actually grabbed version
<img width="383" alt="itWork" src="https://github.com/user-attachments/assets/e4dfc739-a1c8-4164-860f-d9e1199ce29d">
