### PR TITLE
bugfix: Remove a semicolon that caused a -Werror=pedantic issue

### DIFF
--- a/samplePDF/StructsTutorial.h
+++ b/samplePDF/StructsTutorial.h
@@ -74,7 +74,7 @@ inline MaCh3Mode NuWroModeToMaCh3Mode(int NuWroMode) {
   }
 
   return ReturnMode;
-};
+}
 
 inline std::string ModeToString(int Mode) {
   std::string ModeString;


### PR DESCRIPTION
# Pull request description:
Minor bug fix - Remove a semicolon that -Werror=pedantic caught as an error during compilation

## Changes or fixes:
Here's the error output:
```
In file included from /mnt/home/yprabhu/OA2024/MaCh3/REFACTOR/MaCh3Tutorial/splines/BinnedSplinesTutorial.cpp:3:
/mnt/home/yprabhu/OA2024/MaCh3/REFACTOR/MaCh3Tutorial/splines/../samplePDF/StructsTutorial.h:77:2: error: extra ';' [-Werror=pedantic]
 };
  ^
cc1plus: all warnings being treated as errors
make[2]: *** [splines/CMakeFiles/BinnedSplinesTutorial.dir/build.make:76: splines/CMakeFiles/BinnedSplinesTutorial.dir/BinnedSplinesTutorial.cpp.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:2943: splines/CMakeFiles/BinnedSplinesTutorial.dir/all] Error 2
make: *** [Makefile:156: all] Error 2
```

and after removing the semicolon, MaCh3Tutorial compiles successfully:

```
[ 85%] Linking CXX shared library libBinnedSplinesTutorial.so
[ 85%] Built target BinnedSplinesTutorial
[ 86%] Building CXX object samplePDF/CMakeFiles/samplePDFTutorial.dir/samplePDFTutorial.cpp.o
[ 86%] Linking CXX shared library libsamplePDFTutorial.so
[ 86%] Built target samplePDFTutorial
```


## Examples:
