### PR TITLE
feat: Add lib64 to LD_LIBRARY_PATH

### DIFF
--- a/cmake/Templates/setup.MaCh3Tutorial.sh.in
+++ b/cmake/Templates/setup.MaCh3Tutorial.sh.in
@@ -62,5 +62,6 @@ export MACH3=${SETUPDIR}
 
 add_to_PATH ${MaCh3Tutorial_ROOT}/CIValidations
 add_to_LD_LIBRARY_PATH ${MaCh3Tutorial_ROOT}/lib
+add_to_LD_LIBRARY_PATH ${MaCh3Tutorial_ROOT}/lib64
 
 unset SETUPDIR


### PR DESCRIPTION
# Pull request description
Some libraries are stored in lib64 so we should add this to our environment. Whilst right now this isn't a breaking issue some future dependencies may use this so best to fix now
