### PR TITLE
bugfix: removing override from GetSampleName as the function is now pure virtual

### DIFF
--- a/CIValidations/SigmaVarValidations.cpp
+++ b/CIValidations/SigmaVarValidations.cpp
@@ -79,7 +79,7 @@ class samplePDFSigmaVar : public samplePDFTutorial
     } // end constructor
 
     inline M3::int_t GetNsamples() override { return 22; };
-    std::string GetSampleName(int Sample) override {return SampleBlarbTitle[Sample];};
+    std::string GetSampleName(int Sample) {return SampleBlarbTitle[Sample];};
     inline std::string GetKinVarLabel(const int sample, const int Dimension) override {return KinemBlarbTitle[Dimension];}
 
      inline void SetupBinning(const M3::int_t Selection, std::vector<double> &BinningX, std::vector<double> &BinningY) override{

--- a/CIValidations/pValueValidations.cpp
+++ b/CIValidations/pValueValidations.cpp
@@ -40,7 +40,7 @@ class samplePDFpValue : public samplePDFTutorial
     KinemBlarbTitle({"RecoLeptonMomentum", "RecoLeptonCosTheta"}) {}
 
     inline M3::int_t GetNsamples() override { return 22; };
-    std::string GetSampleName(int Sample) override {return SampleBlarbTitle[Sample];};
+    std::string GetSampleName(int Sample) {return SampleBlarbTitle[Sample];};
     inline std::string GetKinVarLabel(const int sample, const int Dimension) override {return KinemBlarbTitle[Dimension];}
 
      inline void SetupBinning(const M3::int_t Selection, std::vector<double> &BinningX, std::vector<double> &BinningY) override{


### PR DESCRIPTION
# Pull request description:
GetSampleName is now pure virtual so override is no longer needed.

## Changes or fixes:


## Examples:
