### PR TITLE
feat: Adding option to do adaptive MCMC as well

### DIFF
--- a/Tutorial/MCMCTutorial.cpp
+++ b/Tutorial/MCMCTutorial.cpp
@@ -1,4 +1,6 @@
 // MaCh3 includes
+#include "manager/MaCh3Logger.h"
+#include "manager/YamlHelper.h"
 #include "mcmc/MaCh3Factory.h"
 #include "samplePDF/samplePDFTutorial.h"
 
@@ -9,6 +11,11 @@ int main(int argc, char *argv[]) {
   // Initialise covariance class reasonable for Systematics
   auto xsec = MaCh3CovarianceFactory<covarianceXsec>(FitManager.get(), "Xsec");
   auto osc  = MaCh3CovarianceFactory<covarianceOsc>(FitManager.get(), "Osc");
+
+  if(CheckNodeExists(FitManager->raw(), "General", "AdaptionOptions")){
+    MACH3LOG_INFO("Initialising adaptive MCMC for parameters in {}", xsec->getName());
+    xsec->initialiseAdaption(FitManager->raw()["General"]);
+  }
 
   // Initialise samplePDF
   auto SampleConfig = FitManager->raw()["General"]["TutorialSamples"].as<std::vector<std::string>>();


### PR DESCRIPTION
# Pull request description:
adding in a check to see if "AdaptionOptions" exists in the fit config file. If yes then it will try to setup adaptive MCMC

## Changes or fixes:


## Examples:
```
  if(CheckNodeExists(FitManager->raw(), "General", "AdaptionOptions")){
    MACH3LOG_INFO("Initialising adaptive MCMC for parameters in {}", xsec->getName());
    xsec->initialiseAdaption(FitManager->raw()["General"]);
  }
```