### PR TITLE
bugfix: Update baseline upper bound to be 9999

### DIFF
--- a/TutorialConfigs/CovObjs/OscillationModel.yaml
+++ b/TutorialConfigs/CovObjs/OscillationModel.yaml
@@ -127,7 +127,7 @@ Systematics:
     SampleNames: ["Tutorial Beam"]
     Error: 1.0
     FlatPrior: true
-    ParameterBounds: [0, 999]
+    ParameterBounds: [0, 9999]
     ParameterGroup: Osc
     ParameterValues:
       Generated: 295


### PR DESCRIPTION
# Pull request description:
Update baseline upper bound to `9999 km` so someone copying/pasting this config only needs to make minimal changes

