### PR TITLE
tidy: use composite squash action from core

### DIFF
--- a/.github/workflows/CIValidations.yml
+++ b/.github/workflows/CIValidations.yml
@@ -43,7 +43,7 @@ jobs:
 
           - name: NuDock Validations
             test: MaCh3CLI --NuDockValidations
-            compilation_flags: -MaCh3Tutorial_NUDOCK_ENABLED=ON
+            compilation_flags: -DMaCh3Tutorial_NUDOCK_ENABLED=ON
 
     container:
       image: ghcr.io/mach3-software/mach3:alma9v1.3.0

--- a/.github/workflows/Squash.yml
+++ b/.github/workflows/Squash.yml
@@ -26,14 +26,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
-        with:
-          ref: ${{ matrix.branch_name }}
-          fetch-depth: 0
 
       - name: Squash commits
-        run: |
-          git config --global user.name "GitHub Actions"
-          git config --global user.email "actions@github.com"
-          git reset --soft "$(git rev-list --max-parents=0 HEAD)"
-          git commit --amend -m "Squashed all commits into one"
-          git push origin ${{ matrix.branch_name }} --force
+        uses: mach3-software/MaCh3/.github/actions/squash@develop
+        with:
+          branch: ${{ matrix.branch_name }}


### PR DESCRIPTION
# Pull request description:
As title says, but main goal is to use composite action in core and this way avoid copy pasting logic here.

## Changes or fixes:


## Examples:
