### PR TITLE
bugfix: umbrella off by default, move solve config to Diag yaml

### DIFF
--- a/Tutorial/TutorialDiagConfig.yaml
+++ b/Tutorial/TutorialDiagConfig.yaml
@@ -163,3 +163,38 @@ MatrixPlotter:
 SmearChain:
   Smear: [ ["delm2_23", "delta_cp"], [2.70e-5, 0.01]]
   SaveUnsmearedBranch: false
+
+
+#########################################
+# Umbrella Sampling Configuration
+# Convergence parameters
+UmbrellaSolve:
+  max_iterations: 200000
+  tolerance: 1e-10
+  print_frequency: 500
+  # Performance options
+  use_openmp: true
+
+  dynamic_files: true
+  dynamic_pattern: "path/to/individual/umbrella/files"
+  dynamic_n_windows: 60
+
+  # Output file
+  output_file: "umbrella_output.root"
+
+  # Variable of interest (branch name)
+  variable_of_interest: "delta_cp"
+
+  # Manual window configuration (if dynamic_files is false)
+  windows:
+    - name: "window_0"
+      center: 0.0
+      width: 0.04
+      
+    - name: "window_1" 
+      center: 0.17453292519943295
+      width: 0.04
+
+  input_files:
+    - "path/to/umbrella_window_0.root"
+    - "path/to/umbrella_window_1.root"

--- a/TutorialConfigs/FitterConfig.yaml
+++ b/TutorialConfigs/FitterConfig.yaml
@@ -32,7 +32,7 @@ General:
     
     # This section configures Multicanonnical MCMC, using biases to change how chains sample specific regions of the parameter space
     Multicanonical:
-      Enabled: true
+      Enabled: false 
       Beta: 1.0 # bias strength parameter, 1.0 is full strength, 0.0 is no bias
       Spline:
       # Choose a spline for a given parameter to bias your chain. Can be used to flatten out the sampling of a particular parameter, with the bias divides out later.


### PR DESCRIPTION
# Pull request description:

Sets umbrella sampling to default to off. 

Moves content of umbrella_solve.yaml from core to expt specific Diag yaml.
